### PR TITLE
Restrict availability of terraform apply with atlantis

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,6 +1,7 @@
 version: 2
 projects:
 - dir: infra/terraform/resources/example
+  apply_requirements: [approved, mergeable]
   workflow: terrahelp
 workflows:
   terrahelp:

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,7 +1,6 @@
 version: 2
 projects:
 - dir: infra/terraform/resources/example
-  apply_requirements: [mergeable]
   workflow: terrahelp
 workflows:
   terrahelp:

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,7 +1,7 @@
 version: 2
 projects:
 - dir: infra/terraform/resources/example
-  apply_requirements: [approved, mergeable]
+  apply_requirements: [mergeable]
   workflow: terrahelp
 workflows:
   terrahelp:

--- a/infra/terraform/resources/example/main.tf
+++ b/infra/terraform/resources/example/main.tf
@@ -18,7 +18,7 @@ module "s3" {
   bucket_name = "mojap-atlantis-test-bucket"
 }
 
-// module "lambda_function" {
-//   source          = "../../modules/lambda_function"
-//   sensitive_value = "${var.lambda_sensitive_value}"
-// }
+module "lambda_function" {
+  source          = "../../modules/lambda_function"
+  sensitive_value = "${var.lambda_sensitive_value}"
+}

--- a/infra/terraform/resources/example/main.tf
+++ b/infra/terraform/resources/example/main.tf
@@ -18,7 +18,7 @@ module "s3" {
   bucket_name = "mojap-atlantis-test-bucket"
 }
 
-module "lambda_function" {
-  source          = "../../modules/lambda_function"
-  sensitive_value = "${var.lambda_sensitive_value}"
-}
+// module "lambda_function" {
+//   source          = "../../modules/lambda_function"
+//   sensitive_value = "${var.lambda_sensitive_value}"
+// }

--- a/infra/terraform/resources/example/outputs.tf
+++ b/infra/terraform/resources/example/outputs.tf
@@ -1,4 +1,4 @@
-// output "lambda_sensitive_value" {
-//   value     = "${module.lambda_function.sensitive_value}"
-//   sensitive = true
-// }
+output "lambda_sensitive_value" {
+  value     = "${module.lambda_function.sensitive_value}"
+  sensitive = true
+}

--- a/infra/terraform/resources/example/outputs.tf
+++ b/infra/terraform/resources/example/outputs.tf
@@ -1,4 +1,4 @@
-output "lambda_sensitive_value" {
-  value     = "${module.lambda_function.sensitive_value}"
-  sensitive = true
-}
+// output "lambda_sensitive_value" {
+//   value     = "${module.lambda_function.sensitive_value}"
+//   sensitive = true
+// }


### PR DESCRIPTION
this change requires that a PR be approved and in a mergable state for Atlantis to be able to run `terraform apply`